### PR TITLE
Use BusyBox-compatible cp for asset copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ OVERRIDE_DIR=/media/developer/apps/usr/palm/applications/tld.my.customhome/asset
 umount "$ASSETS_DIR" 2>/dev/null || true
 rm -rf /tmp/weboshome-merged
 mkdir /tmp/weboshome-merged
-cp -R --no-dereference "$ASSETS_DIR"/. /tmp/weboshome-merged/
+cp -a "$ASSETS_DIR"/. /tmp/weboshome-merged/
 
 # Replace i18n symlink with real directory
 rm /tmp/weboshome-merged/i18n


### PR DESCRIPTION
BusyBox 1.35 cp on webOS 10.3.1 does not list the GNU-style --no-dereference option. Use the supported archive form instead; cp -a preserves the i18n symlink and was verified through manual apply, reboot rollback, and webosbrew init.d startup on an LG G2.